### PR TITLE
As far as I can tell there is no sane way to do line items as QBXML

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,36 @@ Convert a ruby hash to QBXML and validate all types
 q.to_qbxml(hsh, validate: true)
 ```
 
+Convert a ruby hash to QBXML with line items:
+```ruby
+  {
+    line_items: [
+    {
+      invoice_line_add: {
+        desc: "Line 1"
+      }
+    },
+    {
+      invoice_line_add: {
+        desc: "Line 2"
+      }
+    }
+    ]
+  }
+```
+
+The `line_items` will be omitted in the final XML yielding a proper:
+```xml
+<InvoiceAddRq>
+    <InvoiceLineAdd>
+      <Desc>Line 1</Desc>
+    </InvoiceLineAdd>
+    <InvoiceLineAdd>
+      <Desc>Line 2</Desc>
+    </InvoiceLineAdd>
+</InvoiceAddRq>
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/qbxml/hash.rb
+++ b/lib/qbxml/hash.rb
@@ -10,6 +10,7 @@ class Qbxml::Hash < ::Hash
   CONTENT_ROOT = '__content__'.freeze
   ATTR_ROOT    = 'xml_attributes'.freeze
   IGNORED_KEYS = [ATTR_ROOT]
+  LINE_ITEM = 'LineItems' 
 
 
   def self.from_hash(hash, opts = {}, &block)
@@ -30,11 +31,26 @@ class Qbxml::Hash < ::Hash
   def self.to_xml(hash, opts = {})
     opts[:root], hash = hash.first
     opts[:attributes] = hash.delete(ATTR_ROOT)
-    hash_to_xml(hash, opts)
+    xml = hash_to_xml(hash, opts)
+    doc = Nokogiri.XML(xml)
+    doc = remove_tags_preserve_content(doc, LINE_ITEM)
+    doc.to_xml
   end
 
   def self.from_xml(xml, opts = {})
     from_hash(xml_to_hash(Nokogiri::XML(xml).root, {}, opts), opts)
+  end
+
+  def self.remove_tags_preserve_content(doc, name)
+    doc.xpath(".//#{name}").reverse.each do |element|
+      element.children.reverse.each do |child|
+        child_clone = child.clone
+        element.add_next_sibling child_clone
+        child.unlink
+      end
+      element.unlink
+    end
+    doc
   end
 
 private

--- a/spec/lib/qbxml/hash_spec.rb
+++ b/spec/lib/qbxml/hash_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Qbxml::Hash do
+  let(:qbxml) { Qbxml.new(:qb) }
+
+  describe "self.remove_tags_preserve_content" do
+    it "should remove all LineItems parent tags" do
+      hash = { line_items: [ line_item(1), line_item(2) ] }
+      hash = boilerplate('invoice', hash)
+      xml = qbxml.to_qbxml(hash)
+      expect(xml).to_not match /LineItems/
+    end
+
+    it "should remove all LineItems parent tags even with a tag called IncludeLineItems" do
+      hash = { include_line_items: [ line_item(1), line_item(2) ] }
+      hash = boilerplate('invoice', hash)
+      xml = qbxml.to_qbxml(hash)
+      expect(xml).to_not match /\<LineItems/
+    end
+  end
+
+  def line_item(line_number)
+    {
+      invoice_line_add: {
+        item_ref: {
+          list_id: '3243'
+        },
+        desc: "Line #{line_number}",
+        amount: 10.99,
+        is_taxable: true,
+        quantity: 3,
+        rate_percent: 0,
+        line_items: [{
+          line: {
+            desc: 'inside'
+          }
+        }]
+      }
+    }
+  end
+
+  def boilerplate(type, body_hash, options = {})
+    {  :qbxml_msgs_rq =>
+       [
+         {
+           :xml_attributes =>  { "onError" => "stopOnError"},
+           "#{type}_rq".to_sym =>
+           [
+             {
+               :xml_attributes => { "requestID" => "#{options[:id] || 1}" },
+               "#{type}_#{options[:action] || 'add'}_rq".to_sym => body_hash
+             }
+           ]
+         }
+       ]
+    }
+  end
+end


### PR DESCRIPTION
wants them given a hash. For example QBXML wants
<InvoiceLineAdd>
  ....
</InvoiceLineAdd>
<InvoiceLineAdd>
  ....
</InvoiceLineAdd>

But all I can get using a Hash is a parent wrapper around that such as:
<LineItems>
  <InvoiceLineAdd>
    ....
  </InvoiceLineAdd>
  <InvoiceLineAdd>
    ....
  </InvoiceLineAdd>
  ..

This commit will allow the usage of a parent hash node called
"line_items:", which will not be outputed in the final XML.

See spec/lib/qbxml/hash_spec.rb
